### PR TITLE
fix: extra closing bracket when parsing template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "detypes",
   "version": "0.8.0",
-  "packageManager": "pnpm@9.1.0",
+  "packageManager": "pnpm@9.5.0",
   "description": "Removes TypeScript type annotations but keeps the formatting",
   "author": "Dunqing <dengqing0821@gmail.com>",
   "license": "MIT",
@@ -26,11 +26,11 @@
       "require": "./dist/index.js"
     }
   },
+  "main": "dist/index.js",
   "bin": "detype.js",
   "files": [
-    "README.md",
-    "detype.js",
-    "dist"
+    "dist/**/*",
+    "index.d.ts"
   ],
   "engines": {
     "node": ">=18"

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -219,7 +219,7 @@ export async function transformVue(
     const lines = expressionCode.split(delimiter)
     for (let i = 0; i < locs.length; i++) {
       const loc = locs[i]
-      const line = lines[i]
+      const line = lines[i].trim()
       ms.update(loc[0], loc[1], line.substring(1, line.length - 2))
     }
   }


### PR DESCRIPTION
Related issue https://github.com/unovue/shadcn-vue/discussions/632

Fix the extra `whitespace` at `line` causing the `substring` to truncate the string wrongly, leaving extra closing bracket.


